### PR TITLE
Replace rcov with simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development do
   gem "cucumber"
   gem "bundler"
   gem "jeweler", "~> 2.0.0"
-  gem "rcov", ">= 0"
   gem 'money', '3.1.5'
 end
 
@@ -20,6 +19,7 @@ group :test do
   gem "shoulda-matchers"
   gem "factory_girl", "3.6.2"
   gem "state_machine"
+  gem 'simplecov', :require => false
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     debugger-ruby_core_source (1.3.1)
     descendants_tracker (0.0.3)
     diff-lcs (1.2.5)
+    docile (1.1.2)
     erubis (2.7.0)
     factory_girl (3.6.2)
       activesupport (>= 3.0.0)
@@ -115,7 +116,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.1)
-    rcov (0.9.11)
     rdoc (4.1.0)
       json (~> 1.4)
     rspec (2.13.0)
@@ -128,6 +128,11 @@ GEM
     rspec-mocks (2.13.1)
     shoulda-matchers (2.4.0)
       activesupport (>= 3.0.0)
+    simplecov (0.8.2)
+      docile (~> 1.1.0)
+      multi_json
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
     sprockets (2.10.1)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -160,9 +165,9 @@ DEPENDENCIES
   jeweler (~> 2.0.0)
   money (= 3.1.5)
   rails (~> 4.0.0)
-  rcov
   rspec (~> 2.13.0)
   shoulda-matchers
+  simplecov
   sqlite3 (~> 1.3.8)
   state_machine
   yard (~> 0.6.0)

--- a/Rakefile
+++ b/Rakefile
@@ -35,11 +35,6 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
-RSpec::Core::RakeTask.new(:rcov) do |spec|
-  spec.pattern = 'spec/**/*_spec.rb'
-  spec.rcov = true
-end
-
 require 'cucumber/rake/task'
 Cucumber::Rake::Task.new(:features)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,9 @@ require 'active_record'
 require 'active_support'
 require 'active_support/test_case'
 require 'shoulda-matchers'
+require 'simplecov'
+
+SimpleCov.start
 
 Carter::Initializer.setup 
 # Requires supporting files with custom matchers and macros, etc,


### PR DESCRIPTION
Rcov is no longer supported in Ruby 1.9+.  This replaces it with Simplecov instead. I've tested this under ruby 2.1 and all tests pass and coverage report shows 98.98% covered.
